### PR TITLE
Updates for new versions of logstash support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ coverage/
 
 # Mac
 .DS_Store
+
+#vscode
+.vscode

--- a/lib/logstash/outputs/seq.rb
+++ b/lib/logstash/outputs/seq.rb
@@ -110,12 +110,12 @@ class LogStash::Outputs::Seq < LogStash::Outputs::Base
   private
   def to_seq_payload(event)
     props = {
-        '@Version' => event['@version']
+        '@Version' => event.get('@version')
     }
     payload = {
-        :Timestamp => event['@timestamp'],
+        :Timestamp => event.get('@timestamp'),
         :Level => get_level(event),
-        :MessageTemplate => event['message'],
+        :MessageTemplate => event.get('message'),
         :Properties => props
     }
 
@@ -128,7 +128,7 @@ class LogStash::Outputs::Seq < LogStash::Outputs::Base
 
   private
   def get_level(event)
-    level = event['@level']
+    level = event.get('@level')
 
     level ? level : 'Verbose'
   end # def get_level

--- a/lib/version-info.rb
+++ b/lib/version-info.rb
@@ -1,7 +1,7 @@
 module LogStash
   module Output
     module Seq
-      VERSION = '0.0.3'
+      VERSION = '0.0.4'
     end
   end
 end

--- a/logstash-output-seq.gemspec
+++ b/logstash-output-seq.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  spec.add_runtime_dependency "logstash-core", ">= 2.3.4", "< 3.0.0"
-  spec.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.4", "< 3.0.0"
+  spec.add_runtime_dependency "logstash-core", ">= 2.3.4", "~> 6"
+  spec.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.4", "~> 6"
   spec.add_runtime_dependency "logstash-codec-plain"
 
   spec.add_development_dependency "coveralls", "~> 0.8"

--- a/logstash-output-seq.gemspec
+++ b/logstash-output-seq.gemspec
@@ -24,8 +24,9 @@ Gem::Specification.new do |spec|
   spec.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  spec.add_runtime_dependency "logstash-core", ">= 2.3.4", "~> 6"
+  spec.add_runtime_dependency "logstash-core", ">= 2.3.4", "<= 6"
   spec.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.4", "~> 6"
+  spec.add_runtime_dependency "logstash-core-plugin-api", ">= 2.1.28", "<= 2.99"
   spec.add_runtime_dependency "logstash-codec-plain"
 
   spec.add_development_dependency "coveralls", "~> 0.8"


### PR DESCRIPTION
This is just a bit premature, but wanted to just get this out there.  This compiles, installs to logstash and runs, but I do get a null reference, at the below stack trace.  On the way to fixing #1 .  Please provide feedback, looking to learn more Ruby so any tips or pointers you can give would be great.  Thanks!


```{:error=>#<NoMethodError: undefined method `each' for nil:NilClass>, :backtrace=>["C:/logstash-6.4.1/vendor/local_gems/04b715e6/logstash-output-seq-0.0.4/lib/logstash/outputs/seq.rb:122:in `to_seq_payload'", "C:/logstash-6.4.1/vendor/local_gems/04b715e6/logstash-output-seq-0.0.4/lib/logstash/outputs/seq.rb:51:in `block in multi_receive'"```


-Update dependencies
-Update event['field'] references event.get('field')
-Update gitignore
-Update version to 0.0.4

Thanks for contributing to the Seq output plugin for Logstash!
