### PR TITLE
Feature/build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
+---
 sudo: false
 language: ruby
 cache: bundler
-rvm:
-  - jruby-9.1.17
-script:
-  - bundle exec rake vendor
-  - bundle exec rake
+matrix:
+  include:
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=master
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.x
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.0
+  - rvm: jruby-1.7.27
+    env: LOGSTASH_BRANCH=5.6
+  fast_finish: true
+install: true
+script: ci/build.sh
+jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.25
+  - jruby-9.1.17.0
 script:
   - bundle exec rake vendor
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - jruby-9.1.17.0
+  - jruby-9.1.17
 script:
   - bundle exec rake vendor
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ cache: bundler
 rvm:
   - jruby-1.7.25
 script:
+  - bundle exec rake vendor
   - bundle exec rake

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,7 +2,8 @@ The following is a list of people who have contributed ideas, code, bug
 reports, or in general have helped the Seq plugin for Logstash along its way.
 
 Contributors:
-* Adam Friedman (tintoy)
+* Adam Friedman ([@tintoy](https://github.com/tintoy))
+* [@mjnorman](https://github.com/mjnorman)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,11 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
+
 gemspec
+
+logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
+
+if Dir.exist?(logstash_path) && use_logstash_source
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,6 +8,7 @@
 ########################################################
 set -e
 
+echo ""
 echo "Starting build process in: `pwd`"
 source ./ci/setup.sh
 
@@ -20,3 +21,4 @@ else
     bundle exec rake vendor
     bundle exec rspec spec
 fi
+echo ""

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# version: 1
+
+########################################################
+#
+# AUTOMATICALLY GENERATED! DO NOT EDIT
+#
+########################################################
+set -e
+
+echo "Starting build process in: `pwd`"
+source ./ci/setup.sh
+
+if [[ -f "ci/run.sh" ]]; then
+    echo "Running custom build script in: `pwd`/ci/run.sh"
+    source ./ci/run.sh
+else
+    echo "Running default build scripts in: `pwd`/ci/build.sh"
+    bundle install
+    bundle exec rake vendor
+    bundle exec rspec spec
+fi

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# version: 1
+
+########################################################
+#
+# AUTOMATICALLY GENERATED! DO NOT EDIT
+#
+########################################################
+set -e
+if [ "$LOGSTASH_BRANCH" ]; then
+    echo "Building plugin using Logstash source"
+    BASE_DIR=`pwd`
+    echo "Checking out branch: $LOGSTASH_BRANCH"
+    git clone -b $LOGSTASH_BRANCH https://github.com/elastic/logstash.git ../../logstash --depth 1
+    printf "Checked out Logstash revision: %s\n" "$(git -C ../../logstash rev-parse HEAD)"
+    cd ../../logstash
+    echo "Building plugins with Logstash version:"
+    cat versions.yml
+    echo "---"
+    # We need to build the jars for that specific version
+    echo "Running gradle assemble in: `pwd`"
+    ./gradlew assemble
+    cd $BASE_DIR
+    export LOGSTASH_SOURCE=1
+else
+    echo "Building plugin using released gems on rubygems"
+fi

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -6,6 +6,8 @@
 # AUTOMATICALLY GENERATED! DO NOT EDIT
 #
 ########################################################
+
+echo ""
 set -e
 if [ "$LOGSTASH_BRANCH" ]; then
     echo "Building plugin using Logstash source"
@@ -25,3 +27,5 @@ if [ "$LOGSTASH_BRANCH" ]; then
 else
     echo "Building plugin using released gems on rubygems"
 fi
+
+echo ""

--- a/lib/logstash/outputs/seq.rb
+++ b/lib/logstash/outputs/seq.rb
@@ -119,7 +119,7 @@ class LogStash::Outputs::Seq < LogStash::Outputs::Base
         :Properties => props
     }
 
-    event.instance_variable_get(:@data).each do |property, value|
+    event.to_hash.each do |property, value|
       props[property] = value unless @@ignore_properties.has_key? property
     end
 

--- a/lib/logstash/outputs/seq.rb
+++ b/lib/logstash/outputs/seq.rb
@@ -110,12 +110,12 @@ class LogStash::Outputs::Seq < LogStash::Outputs::Base
   private
   def to_seq_payload(event)
     props = {
-        '@Version' => event['@version']
+        '@Version' => event.get('@version')
     }
     payload = {
-        :Timestamp => event['@timestamp'],
+        :Timestamp => event.get('@timestamp'),
         :Level => get_level(event),
-        :MessageTemplate => event['message'],
+        :MessageTemplate => event.get('message'),
         :Properties => props
     }
 
@@ -128,7 +128,7 @@ class LogStash::Outputs::Seq < LogStash::Outputs::Base
 
   private
   def get_level(event)
-    level = event['@level']
+    level = event.get('@level')
 
     level ? level : 'Verbose'
   end # def get_level

--- a/lib/version-info.rb
+++ b/lib/version-info.rb
@@ -1,7 +1,7 @@
 module LogStash
   module Output
     module Seq
-      VERSION = '0.0.3'
+      VERSION = '0.1.0'
     end
   end
 end

--- a/lib/version-info.rb
+++ b/lib/version-info.rb
@@ -1,7 +1,7 @@
 module LogStash
   module Output
     module Seq
-      VERSION = '0.1.0'
+      VERSION = '0.2.0'
     end
   end
 end

--- a/logstash-output-seq.gemspec
+++ b/logstash-output-seq.gemspec
@@ -15,23 +15,25 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/tintoy/logstash-output-seq"
   spec.require_paths = ["lib"]
 
+  spec.require_paths = ["lib"]
+
   # Files
-  spec.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE']
+  spec.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
    # Tests
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
 
   # Special flag to let us know this is actually a logstash plugin
   spec.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
-  # Gem dependencies
-  spec.add_runtime_dependency "logstash-core", ">= 2.3.4", "<= 6"
-  spec.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.4", "~> 6"
-  spec.add_runtime_dependency "logstash-core-plugin-api", ">= 2.1.28", "<= 2.99"
+  # Dependencies
+  spec.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   spec.add_runtime_dependency "logstash-codec-plain"
+  spec.add_runtime_dependency "logstash-mixin-http_client"
 
+  # Development dependencies
+  spec.add_development_dependency "logstash-devutils"
   spec.add_development_dependency "coveralls", "~> 0.8"
   spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "logstash-devutils", "~> 0.0.15"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "rake", "~> 11.2"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/logstash-output-seq.gemspec
+++ b/logstash-output-seq.gemspec
@@ -24,8 +24,9 @@ Gem::Specification.new do |spec|
   spec.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  spec.add_runtime_dependency "logstash-core", ">= 2.3.4", "< 3.0.0"
-  spec.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.4", "< 3.0.0"
+  spec.add_runtime_dependency "logstash-core", ">= 2.3.4", "<= 6"
+  spec.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.4", "~> 6"
+  spec.add_runtime_dependency "logstash-core-plugin-api", ">= 2.1.28", "<= 2.99"
   spec.add_runtime_dependency "logstash-codec-plain"
 
   spec.add_development_dependency "coveralls", "~> 0.8"

--- a/spec/outputs/seq_spec.rb
+++ b/spec/outputs/seq_spec.rb
@@ -6,7 +6,7 @@ require 'logstash/event'
 require "jrjackson"
 require "sinatra"
 
-require "spec/spec_helper"
+require_relative "../spec_helper"
 
 describe LogStash::Outputs::Seq do
   # Output and its configuration

--- a/spec/outputs/seq_spec.rb
+++ b/spec/outputs/seq_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'logstash/devutils/rspec/spec_helper'
 require 'logstash/codecs/plain'
 require 'logstash/event'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'coveralls'
+
 Coveralls.wear!
 
 require 'logstash/outputs/seq'


### PR DESCRIPTION
Update plugin to work against latest version(s) of Logstash.

Relates to tintoy/logstash-output-seq#1 and tintoy/logstash-output-seq#2.

Replaces tintoy/logstash-output-seq#2.

CC: @mjnorman
